### PR TITLE
Create files for the CLOS fabric example in the docs

### DIFF
--- a/clos-fabric/README.md
+++ b/clos-fabric/README.md
@@ -1,0 +1,118 @@
+# Explore using ansible for writing Dell switch configs.
+
+This is meant to get started with just writing the config files and
+not updating a running switch.  This is a helpful first step to working
+with the modules and understanding how the configurations
+are created from input data.
+
+We follow the examle of the CLOS fabric datacenter configuration.
+https://ansible-dellos-docs.readthedocs.io/en/latest/clos_fabric_example.html
+
+See the docs here https://ansible-dellos-docs.readthedocs.io/en/latest/
+
+Clone this examples repo and cd to the cloned directory.
+
+Set up the python env:
+```
+python3 -m venv venv
+. venv/bin/activate
+pip install wheel
+pip install ansible
+```
+
+Change to clos-fabric example:
+```
+cd clos-fabric
+```
+
+Create the list of Dell switch mgmt roles.  We are preferring clones
+from the git repo rather and a static install.
+```
+cat > dellemc_roles.yml << EOF
+- src: https://github.com/Dell-Networking/ansible-role-dellos-aaa
+  name: dellos-aaa
+- src: https://github.com/Dell-Networking/ansible-role-dellos-acl
+  name: dellos-acl
+- src: https://github.com/Dell-Networking/ansible-role-dellos-bgp
+  name: dellos-bgp
+- src: https://github.com/Dell-Networking/ansible-role-dellos-copy-config
+  name: dellos-copy-config
+- src: https://github.com/Dell-Networking/ansible-role-dellos-dcb
+  name: dellos-dcb
+- src: https://github.com/Dell-Networking/ansible-role-dellos-dns
+  name: dellos-dns
+- src: https://github.com/Dell-Networking/ansible-role-dellos-ecmp
+  name: dellos-ecmp
+- src: https://github.com/Dell-Networking/ansible-role-dellos-flow-monitor
+  name: dellos-flow-monitor
+- src: https://github.com/Dell-Networking/ansible-role-dellos-image-upgrade
+  name: dellos-image-upgrade
+- src: https://github.com/Dell-Networking/ansible-role-dellos-interface
+  name: dellos-interface
+- src: https://github.com/Dell-Networking/ansible-role-dellos-lag
+  name: dellos-lag
+- src: https://github.com/Dell-Networking/ansible-role-dellos-lldp
+  name: dellos-lldp
+- src: https://github.com/Dell-Networking/ansible-role-dellos-logging
+  name: dellos-logging
+- src: https://github.com/Dell-Networking/ansible-role-dellos-ntp
+  name: dellos-ntp
+- src: https://github.com/Dell-Networking/ansible-role-dellos-prefix-list
+  name: dellos-prefix-list
+- src: https://github.com/Dell-Networking/ansible-role-dellos-qos
+  name: dellos-qos
+- src: https://github.com/Dell-Networking/ansible-role-dellos-route-map
+  name: dellos-route-map
+- src: https://github.com/Dell-Networking/ansible-role-dellos-sflow
+  name: dellos-sflow
+- src: https://github.com/Dell-Networking/ansible-role-dellos-snmp
+  name: dellos-snmp
+- src: https://github.com/Dell-Networking/ansible-role-dellos-system
+  name: dellos-system
+- src: https://github.com/Dell-Networking/ansible-role-dellos-users
+  name: dellos-users
+- src: https://github.com/Dell-Networking/ansible-role-dellos-vlan
+  name: dellos-vlan
+- src: https://github.com/Dell-Networking/ansible-role-dellos-vlt
+  name: dellos-vlt
+- src: https://github.com/Dell-Networking/ansible-role-dellos-vrf
+  name: dellos-vrf
+- src: https://github.com/Dell-Networking/ansible-role-dellos-vrrp
+  name: dellos-vrrp
+- src: https://github.com/Dell-Networking/ansible-role-dellos-xstp
+  name: dellos-xstp
+
+EOF
+
+```
+
+Install the roles (doesn't work quite like on the [docs install page](https://ansible-dellos-docs.readthedocs.io/en/latest/install.html) says it should unless you create a proper yaml file):
+```
+ansible-galaxy install -r dellemc_roles.yml --roles-path roles/
+```
+
+Note, if you want to remove these roles you can do this:
+```
+ansible-galaxy list --roles-path roles/ | awk '{print $2}' | sed -e 's/,//' | xargs ansible-galaxy role remove  --roles-path roles/
+```
+
+The host config data for the imaginary datacenter switch config.
+Make a directory to hold the configuration snippets
+```
+mkdir tmp/
+```
+
+Run the ansible to write the configuration for the switch.
+This generates a config for a dellos9 and dellos10 switch.
+```
+ansible-playbook -i inventory.yaml datacenter.yaml
+```
+
+You can compare the output formats in the tmp/ dir.
+
+Note the playbook is slightly altered from the CLOS fabric
+example to use the local convention for role names and 
+to add the flag to write the interface config.  It is 
+this flag and  the fact that we can't reach any real switches 
+with the given inventory and creditials that makes this a
+config writing example.

--- a/clos-fabric/datacenter.yaml
+++ b/clos-fabric/datacenter.yaml
@@ -1,0 +1,18 @@
+---
+- hosts: datacenter
+  gather_facts: no
+  connection: local
+  roles:
+        - role: dellos-interface
+          vars:
+            dellos_cfg_generate: true
+        - role: dellos-bgp
+          vars:
+            dellos_cfg_generate: true
+        - role: dellos-snmp
+          vars:
+            dellos_cfg_generate: true
+        - role: dellos-system
+          vars:
+            dellos_cfg_generate: true
+

--- a/clos-fabric/group_vars/all
+++ b/clos-fabric/group_vars/all
@@ -1,0 +1,2 @@
+---
+build_dir: tmp/

--- a/clos-fabric/group_vars/spine.yaml
+++ b/clos-fabric/group_vars/spine.yaml
@@ -1,0 +1,85 @@
+ansible_ssh_user: xxxxx
+ansible_ssh_pass: xxxxx
+ansible_network_os: dellos10
+
+dellos_system:
+  hostname: "{{ spine_hostname }}"
+
+dellos_bgp:
+   asn: 64901
+   router_id: "{{ bgp_router_id }}"
+   best_path:
+      as_path: multipath-relax
+      as_path_state: present
+      med:
+       - attribute: missing-as-worst
+         state: present
+   neighbor:
+     - type: ipv4
+       remote_asn: "{{ bgp_neigh1_remote_asn }}"
+       ip: "{{ bgp_neigh1_ip }}"
+       admin: up
+       state: present
+     - type: ipv4
+       remote_asn: "{{ bgp_neigh2_remote_asn }}"
+       ip: "{{ bgp_neigh2_ip }}"
+       admin: up
+       state: present
+     - type: ipv4
+       remote_asn: "{{ bgp_neigh3_remote_asn }}"
+       ip: "{{ bgp_neigh3_ip }}"
+       admin: up
+       state: present
+     - type: ipv4
+       remote_asn: "{{ bgp_neigh4_remote_asn }}"
+       ip: "{{ bgp_neigh4_ip }}"
+       admin: up
+       state: present
+     - type: ipv6
+       remote_asn: "{{ bgp_neigh5_remote_asn }}"
+       ip: "{{ bgp_neigh5_ip }}"
+       admin: up
+       address_family:
+         - type: ipv4
+           activate: false
+           state: present
+         - type: ipv6
+           activate: true
+           state: present
+       state: present
+     - type: ipv6
+       remote_asn: "{{ bgp_neigh6_remote_asn }}"
+       ip: "{{ bgp_neigh6_ip }}"
+       admin: up
+       address_family:
+         - type: ipv4
+           activate: false
+           state: present
+         - type: ipv6
+           activate: true
+           state: present
+       state: present
+     - type: ipv6
+       remote_asn: "{{ bgp_neigh7_remote_asn }}"
+       ip: "{{ bgp_neigh7_ip }}"
+       admin: up
+       address_family:
+         - type: ipv4
+           activate: false
+           state: present
+         - type: ipv6
+           activate: true
+           state: present
+       state: present
+     - type: ipv6
+       remote_asn: "{{ bgp_neigh8_remote_asn }}"
+       ip: "{{ bgp_neigh8_ip }}"
+       admin: up
+       address_family:
+         - type: ipv4
+           activate: false
+           state: present
+         - type: ipv6
+           activate: true
+           state: present
+   state: present

--- a/clos-fabric/host_vars/leaf1.yaml
+++ b/clos-fabric/host_vars/leaf1.yaml
@@ -1,0 +1,76 @@
+hostname: leaf1
+ansible_ssh_user: xxxxx
+ansible_ssh_pass: xxxxx
+ansible_network_os: dellos10
+dellos_system:
+  hash_algo:
+    algo:
+      - name: ecmp
+        mode: crc
+        state: present
+dellos_interface:
+    ethernet 1/1/1:
+            desc: "Connected to Spine 1"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.1.1.2/24
+            ipv6_and_mask: 2001:100:1:1::2/64
+            state_ipv6: present
+    ethernet 1/1/9:
+            desc: "Connected to Spine 2"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.2.1.2/24
+            ipv6_and_mask: 2001:100:2:1::2/64
+            state_ipv6: present
+dellos_bgp:
+    asn: 64801
+    router_id: 100.0.2.1
+    address_family_ipv4: true
+    address_family_ipv6: true
+    best_path:
+       as_path: multipath-relax
+       as_path_state: present
+       med:
+        - attribute: missing-as-worst
+          state: present
+    neighbor:
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.1.1.1
+        admin: up
+        state: present
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.2.1.1
+        admin: up
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:1:1::1
+        admin: up
+        address_family:
+          - type: ipv4
+            activate: false
+            state: present
+          - type: ipv6
+            activate: true
+            state: present
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:2:1::1
+        admin: up
+        address_family:
+          - type: ipv4
+            activate: false
+            state: present
+          - type: ipv6
+            activate: true
+            state: present
+        state: present
+    state: present

--- a/clos-fabric/host_vars/leaf2.yaml
+++ b/clos-fabric/host_vars/leaf2.yaml
@@ -1,0 +1,80 @@
+hostname: leaf2
+ansible_ssh_user: xxxxx
+ansible_ssh_pass: xxxxx
+ansible_network_os: dellos10
+dellos_system:
+  hash_algo:
+    algo:
+      - name: ecmp
+        mode: crc
+        state: present
+dellos_interface:
+    ethernet 1/1/1:
+            desc: "Connected to Spine 1"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.1.17.2/24
+            ipv6_and_mask: 2001:100:1:11::2/64
+            state_ipv6: present
+    ethernet 1/1/9:
+            desc: "Connected to Spine 2"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.2.17.2/24
+            ipv6_and_mask: 2001:100:2:11::2/64
+dellos_bgp:
+    asn: 64802
+    router_id: 100.0.2.2
+    address_family_ipv4: true
+    address_family_ipv6: true
+    best_path:
+       as_path: multipath-relax
+       as_path_state: present
+       med:
+        - attribute: missing-as-worst
+          state: present
+    neighbor:
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.1.18.1
+        admin: up
+        state: present
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.1.17.1
+        admin: up
+        state: present
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.2.17.1
+        admin: up
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:1:11::1
+        admin: up
+        address_family:
+          - type: ipv4
+            activate: false
+            state: present
+          - type: ipv6
+            activate: true
+            state: present
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:2:11::1
+        admin: up
+        address_family:
+          - type: ipv4
+            activate: false
+            state: present
+          - type: ipv6
+            activate: true
+            state: present
+    state: present
+

--- a/clos-fabric/host_vars/leaf3.yaml
+++ b/clos-fabric/host_vars/leaf3.yaml
@@ -1,0 +1,80 @@
+hostname: leaf3
+ansible_ssh_user: xxxxx
+ansible_ssh_pass: xxxxx
+ansible_network_os: dellos10
+dellos_system:
+  hash_algo:
+    algo:
+      - name: ecmp
+        mode: crc
+        state: present
+dellos_interface:
+    ethernet 1/1/1:
+            desc: "Connected to Spine 1"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.1.33.2/24
+            ipv6_and_mask: 2001:100:1:21::2/64
+            state_ipv6: present
+    ethernet 1/1/9:
+            desc: "Connected to Spine 2"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.2.33.2/24
+            ipv6_and_mask: 2001:100:2:21::2/64
+dellos_bgp:
+    asn: 64803
+    router_id: 100.0.2.3
+    address_family_ipv4: true
+    address_family_ipv6: true
+    best_path:
+       as_path: multipath-relax
+       as_path_state: present
+       med:
+        - attribute: missing-as-worst
+          state: present
+    neighbor:
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.1.33.1
+        admin: up
+        state: present
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.2.33.1
+        admin: up
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:1:21::1
+        admin: up
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:1:22::1
+        admin: up
+        address_family:
+          - type: ipv4
+            activate: false
+            state: present
+          - type: ipv6
+            activate: true
+            state: present
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:2:21::1
+        admin: up
+        address_family:
+          - type: ipv4
+            activate: false
+            state: present
+          - type: ipv6
+            activate: true
+            state: present
+    state: present
+

--- a/clos-fabric/host_vars/leaf4.yaml
+++ b/clos-fabric/host_vars/leaf4.yaml
@@ -1,0 +1,75 @@
+hostname: leaf4
+ansible_ssh_user: xxxxx
+ansible_ssh_pass: xxxxx
+ansible_network_os: dellos10
+dellos_system:
+  hash_algo:
+    algo:
+      - name: ecmp
+        mode: crc
+        state: present
+dellos_interface:
+    ethernet 1/1/5:
+            desc: "Connected to Spine 1"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.1.49.2/24
+            ipv6_and_mask: 2001:100:1:31::2/64
+            state_ipv6: present
+    ethernet 1/1/17:
+            desc: "Connected to Spine 2"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.2.49.2/24
+            ipv6_and_mask: 2001:100:2:31::2/64
+            state_ipv6: present
+dellos_bgp:
+    asn: 64804
+    router_id: 100.0.2.4
+    address_family_ipv4: true
+    address_family_ipv6: true
+    best_path:
+       as_path: multipath-relax
+       as_path_state: present
+       med:
+        - attribute: missing-as-worst
+          state: present
+    neighbor:
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.1.49.1
+        admin: up
+        state: present
+      - type: ipv4
+        remote_asn: 64901
+        ip: 100.2.49.1
+        admin: up
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:1:31::1
+        admin: up
+        address_family:
+          - type: ipv4
+            activate: false
+            state: present
+          - type: ipv6
+            activate: true
+            state: present
+        state: present
+      - type: ipv6
+        remote_asn: 64901
+        ip: 2001:100:2:31::1
+        admin: up
+        address_family:
+          - type: ipv4
+            activate: false
+            state: present
+          - type: ipv6
+            activate: true
+            state: present
+    state: present

--- a/clos-fabric/host_vars/spine1.yaml
+++ b/clos-fabric/host_vars/spine1.yaml
@@ -1,0 +1,62 @@
+hostname: spine1
+ansible_ssh_user: xxxxx
+ansible_ssh_pass: xxxxx
+ansible_network_os: dellos10
+spine_hostname: "spine-1"
+
+dellos_interface:
+    ethernet 1/1/1:
+            desc: "Connected to leaf 1"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.1.1.1/24
+            ipv6_and_mask: 2001:100:1:1::1/64
+            state_ipv6: present
+    ethernet 1/1/17:
+            desc: "Connected to leaf 2"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.1.33.1/24
+            ipv6_and_mask: 2001:100:1:21::1/64
+            state_ipv6: present
+    ethernet 1/1/25:
+            desc: "Connected to leaf 3"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.1.17.1/24
+            ipv6_and_mask: 2001:100:1:11::1/64
+            state_ipv6: present
+    ethernet 1/1/9:
+            desc: "Connected to leaf 4"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.1.49.1/24
+            ipv6_and_mask: 2001:100:1:31::1/64
+            state_ipv6: present
+
+bgp_router_id: "100.0.1.1"
+bgp_neigh1_remote_asn: 64801
+bgp_neigh1_ip: "100.1.1.2"
+bgp_neigh2_remote_asn: 64803
+bgp_neigh2_ip: "100.1.33.2"
+bgp_neigh3_remote_asn: 64802
+bgp_neigh3_ip: "100.1.17.2"
+bgp_neigh4_remote_asn: 64804
+bgp_neigh4_ip: "100.1.49.2"
+bgp_neigh5_remote_asn: 64801
+bgp_neigh5_ip: "2001:100:1:1::2"
+bgp_neigh6_remote_asn: 64802
+bgp_neigh6_ip: "2001:100:1:11::2"
+bgp_neigh7_remote_asn: 64803
+bgp_neigh7_ip: "2001:100:1:21::2"
+bgp_neigh8_remote_asn: 64804
+bgp_neigh8_ip: "2001:100:1:31::2"
+

--- a/clos-fabric/host_vars/spine2.yaml
+++ b/clos-fabric/host_vars/spine2.yaml
@@ -1,0 +1,60 @@
+hostname: spine2
+ansible_ssh_user: xxxxx
+ansible_ssh_pass: xxxxx
+ansible_network_os: dellos10
+spine_hostname: "spine-2"
+dellos_interface:
+    ethernet 1/1/1:
+            desc: "Connected to leaf 1"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.2.1.1/24
+            ipv6_and_mask: 2001:100:2:1::1/64
+            state_ipv6: present
+    ethernet 1/1/25:
+            desc: "Connected to leaf 2"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.2.17.1/24
+            ipv6_and_mask: 2001:100:2:11::1/64
+            state_ipv6: present
+    ethernet 1/1/17:
+            desc: "Connected to leaf 3"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.2.33.1/24
+            ipv6_and_mask: 2001:100:2:21::1/64
+            state_ipv6: present
+    ethernet 1/1/9:
+            desc: "Connected to leaf 4"
+            mtu: 9216
+            portmode:
+            admin: up
+            switchport: False
+            ip_and_mask: 100.2.49.1/24
+            ipv6_and_mask: 2001:100:2:31::1/64
+            state_ipv6: present
+
+bgp_router_id: "100.0.1.2"
+bgp_neigh1_remote_asn: 64801
+bgp_neigh1_ip: "100.2.1.2"
+bgp_neigh2_remote_asn: 64802
+bgp_neigh2_ip: "100.2.33.2"
+bgp_neigh3_remote_asn: 64803
+bgp_neigh3_ip: "100.2.17.2"
+bgp_neigh4_remote_asn: 64804
+bgp_neigh4_ip: "100.2.49.2"
+bgp_neigh5_remote_asn: 64801
+bgp_neigh5_ip: "2001:100:2:1::2"
+bgp_neigh6_remote_asn: 64802
+bgp_neigh6_ip: "2001:100:2:11::2"
+bgp_neigh7_remote_asn: 64803
+bgp_neigh7_ip: "2001:100:2:21::2"
+bgp_neigh8_remote_asn: 64804
+bgp_neigh8_ip: "2001:100:2:31::2"


### PR DESCRIPTION
This example is customized to write the configuration files
locally by setting the role variable dellos_cfg_generate to true.

https://ansible-dellos-docs.readthedocs.io/en/latest/clos_fabric_example.html

Offering as potential contribution to implemented examples from the Dell Ansible docs.